### PR TITLE
don't write privs for superusers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,7 @@ ENV/
 # End of https://www.gitignore.io/api/python
 *.sw[mnop]
 tmp/
+
+# intellij and friends
+*.iml
+.idea/

--- a/tests/test_memberships.py
+++ b/tests/test_memberships.py
@@ -1,6 +1,7 @@
 from conftest import run_setup_sql
 from pgbedrock import memberships as memb
 from pgbedrock import attributes
+from pgbedrock.context import ATTRIBUTES_TABLE_SUPERUSER
 
 
 ROLE1 = 'charlie'
@@ -45,7 +46,7 @@ def test_analyze_memberships(cursor):
         memb.Q_REVOKE_MEMBERSHIP.format(CURRENT_GROUP1, ROLE3),
     ])
 
-    actual = memb.analyze_memberships(spec, cursor, verbose=False)
+    actual = memb.analyze_memberships(spec, cursor, False, ATTRIBUTES_TABLE_SUPERUSER)
     assert set(actual) == expected
 
 

--- a/tests/test_ownerships.py
+++ b/tests/test_ownerships.py
@@ -2,7 +2,7 @@ from conftest import quoted_object, run_setup_sql
 from pgbedrock import ownerships as own
 from pgbedrock import attributes, privileges
 from pgbedrock.common import ObjectName
-from pgbedrock.context import ObjectInfo
+from pgbedrock.context import ObjectInfo, ATTRIBUTES_TABLE_SUPERUSER
 
 Q_CREATE_SEQUENCE = 'SET ROLE {}; CREATE SEQUENCE {}.{}; RESET ROLE;'
 Q_CREATE_TABLE = 'SET ROLE {}; CREATE TABLE {}.{} AS (SELECT 1+1); RESET ROLE;'
@@ -34,7 +34,7 @@ def test_analyze_ownerships_create_schemas(cursor):
             },
         },
     }
-    actual = own.analyze_ownerships(spec, cursor, verbose=False)
+    actual = own.analyze_ownerships(spec, cursor, False, ATTRIBUTES_TABLE_SUPERUSER)
 
     expected = set([
         own.Q_CREATE_SCHEMA.format(ROLES[0], ROLES[0]),
@@ -79,7 +79,7 @@ def test_analyze_ownerships_nonschemas(cursor):
             },
         },
     }
-    actual = own.analyze_ownerships(spec, cursor, verbose=False)
+    actual = own.analyze_ownerships(spec, cursor, False, ATTRIBUTES_TABLE_SUPERUSER)
 
     expected = set([
         own.Q_SET_OBJECT_OWNER.format('TABLE', quoted_object(SCHEMAS[0], TABLES[1]),
@@ -133,7 +133,7 @@ def test_analyze_ownerships_schemas_and_nonschemas(cursor):
             },
         },
     }
-    actual = own.analyze_ownerships(spec, cursor, verbose=False)
+    actual = own.analyze_ownerships(spec, cursor, False, ATTRIBUTES_TABLE_SUPERUSER)
 
     expected = set([
         own.Q_SET_OBJECT_OWNER.format('TABLE', quoted_object(SCHEMAS[0], TABLES[1]),

--- a/tests/test_privileges.py
+++ b/tests/test_privileges.py
@@ -13,6 +13,7 @@ import yaml
 from conftest import quoted_object, run_setup_sql
 from pgbedrock import privileges as privs, attributes, ownerships, spec_inspector
 from pgbedrock.common import ObjectName
+from pgbedrock.context import ATTRIBUTES_TABLE_SUPERUSER
 
 
 Q_CREATE_TABLE = 'SET ROLE {}; CREATE TABLE {}.{} AS (SELECT 1+1); RESET ROLE;'
@@ -221,7 +222,7 @@ def test_analyze_privileges(cursor):
     ])
 
     expected = expected_role0_changes.union(expected_role1_changes).union(expected_role2_changes).union(expected_role4_changes)
-    all_sql_to_run = privs.analyze_privileges(desired_spec, cursor, verbose=False)
+    all_sql_to_run = privs.analyze_privileges(desired_spec, cursor, False, ATTRIBUTES_TABLE_SUPERUSER)
     actual = set(all_sql_to_run)
     expected_but_not_actual = expected.difference(actual)
     actual_but_not_expected = actual.difference(expected)
@@ -246,7 +247,7 @@ def test_analyze_privileges_skips_superuser(cursor):
                         - baz.bip
     """.format(role0=ROLES[0]))
 
-    actual = privs.analyze_privileges(desired_spec, cursor, verbose=False)
+    actual = privs.analyze_privileges(desired_spec, cursor, False, ATTRIBUTES_TABLE_SUPERUSER)
     expected = [privs.SKIP_SUPERUSER_PRIVILEGE_CONFIGURATION_MSG.format(ROLES[0])]
     assert actual == expected
 


### PR DESCRIPTION
old:
```
    SET ROLE "rdsadmin";
    ALTER DEFAULT PRIVILEGES IN SCHEMA yavin_iv GRANT SELECT ON TABLES TO "yavin_iv_service";
    RESET ROLE;
    

    SET ROLE "the_world_tree";
    ALTER DEFAULT PRIVILEGES IN SCHEMA yavin_iv GRANT SELECT ON TABLES TO "yavin_iv_service";
    RESET ROLE;
    

    SET ROLE "rdsadmin";
    ALTER DEFAULT PRIVILEGES IN SCHEMA yavin_iv GRANT DELETE ON TABLES TO "yavin_iv_service";
    RESET ROLE;
    

    SET ROLE "rdsadmin";
    ALTER DEFAULT PRIVILEGES IN SCHEMA yavin_iv GRANT INSERT ON TABLES TO "yavin_iv_service";
    RESET ROLE;
    

    SET ROLE "rdsadmin";
    ALTER DEFAULT PRIVILEGES IN SCHEMA yavin_iv GRANT REFERENCES ON TABLES TO "yavin_iv_service";
    RESET ROLE;
    

    SET ROLE "rdsadmin";
    ALTER DEFAULT PRIVILEGES IN SCHEMA yavin_iv GRANT TRIGGER ON TABLES TO "yavin_iv_service";
    RESET ROLE;
    

    SET ROLE "rdsadmin";
    ALTER DEFAULT PRIVILEGES IN SCHEMA yavin_iv GRANT TRUNCATE ON TABLES TO "yavin_iv_service";
    RESET ROLE;
    

    SET ROLE "rdsadmin";
    ALTER DEFAULT PRIVILEGES IN SCHEMA yavin_iv GRANT UPDATE ON TABLES TO "yavin_iv_service";
    RESET ROLE;
    

    SET ROLE "the_world_tree";
    ALTER DEFAULT PRIVILEGES IN SCHEMA yavin_iv GRANT DELETE ON TABLES TO "yavin_iv_service";
    RESET ROLE;
    

    SET ROLE "the_world_tree";
    ALTER DEFAULT PRIVILEGES IN SCHEMA yavin_iv GRANT INSERT ON TABLES TO "yavin_iv_service";
    RESET ROLE;
    

    SET ROLE "the_world_tree";
    ALTER DEFAULT PRIVILEGES IN SCHEMA yavin_iv GRANT REFERENCES ON TABLES TO "yavin_iv_service";
    RESET ROLE;
    

    SET ROLE "the_world_tree";
    ALTER DEFAULT PRIVILEGES IN SCHEMA yavin_iv GRANT TRIGGER ON TABLES TO "yavin_iv_service";
    RESET ROLE;
    

    SET ROLE "the_world_tree";
    ALTER DEFAULT PRIVILEGES IN SCHEMA yavin_iv GRANT TRUNCATE ON TABLES TO "yavin_iv_service";
    RESET ROLE;
    

    SET ROLE "the_world_tree";
    ALTER DEFAULT PRIVILEGES IN SCHEMA yavin_iv GRANT UPDATE ON TABLES TO "yavin_iv_service";
    RESET ROLE;
    
-- Skipping privilege configuration for superuser "rdsadmin"": permission denied to set role "rdsadmin"
```

new:
```
-- Skipping privilege configuration for superuser "rdsadmin"

    SET ROLE "the_world_tree";
    ALTER DEFAULT PRIVILEGES IN SCHEMA yavin_iv GRANT SELECT ON TABLES TO "yavin_iv_service";
    RESET ROLE;
    
-- Skipping privilege configuration for superuser "rdsadmin"
-- Skipping privilege configuration for superuser "rdsadmin"
-- Skipping privilege configuration for superuser "rdsadmin"
-- Skipping privilege configuration for superuser "rdsadmin"
-- Skipping privilege configuration for superuser "rdsadmin"
-- Skipping privilege configuration for superuser "rdsadmin"

    SET ROLE "the_world_tree";
    ALTER DEFAULT PRIVILEGES IN SCHEMA yavin_iv GRANT DELETE ON TABLES TO "yavin_iv_service";
    RESET ROLE;
    

    SET ROLE "the_world_tree";
    ALTER DEFAULT PRIVILEGES IN SCHEMA yavin_iv GRANT INSERT ON TABLES TO "yavin_iv_service";
    RESET ROLE;
    

    SET ROLE "the_world_tree";
    ALTER DEFAULT PRIVILEGES IN SCHEMA yavin_iv GRANT REFERENCES ON TABLES TO "yavin_iv_service";
    RESET ROLE;
    

    SET ROLE "the_world_tree";
    ALTER DEFAULT PRIVILEGES IN SCHEMA yavin_iv GRANT TRIGGER ON TABLES TO "yavin_iv_service";
    RESET ROLE;
    

    SET ROLE "the_world_tree";
    ALTER DEFAULT PRIVILEGES IN SCHEMA yavin_iv GRANT TRUNCATE ON TABLES TO "yavin_iv_service";
    RESET ROLE;
    

    SET ROLE "the_world_tree";
    ALTER DEFAULT PRIVILEGES IN SCHEMA yavin_iv GRANT UPDATE ON TABLES TO "yavin_iv_service";
    RESET ROLE;
    
-- Skipping privilege configuration for superuser "rdsadmin"

Process finished with exit code 0
```